### PR TITLE
Don't display errors and debugging information by default

### DIFF
--- a/include/vitals.inc.php
+++ b/include/vitals.inc.php
@@ -13,9 +13,6 @@
 
 if (!defined('AC_INCLUDE_PATH')) { exit; }
 
-define('AC_DEVEL', 1);
-define('AC_ERROR_REPORTING', E_ALL ^ E_DEPRECATED ^ E_NOTICE); // default is E_ALL ^ E_NOTICE, use E_ALL or E_ALL + E_STRICT for developing
-
 // Emulate register_globals off. src: http://php.net/manual/en/faq.misc.php#faq.misc.registerglobals
 function unregister_GLOBALS() {
    if (!ini_get('register_globals')) { return; }


### PR DESCRIPTION
Errors and debugging information were being displayed by default.

Not sure if line 17 should have been removed here.  Let me know.
