### PR TITLE
UTF-8 Encoding the REST response

### DIFF
--- a/include/classes/RESTWebServiceOutput.class.php
+++ b/include/classes/RESTWebServiceOutput.class.php
@@ -36,7 +36,7 @@ class RESTWebServiceOutput {
 	
 	// REST templates
 	var $rest_main =
-'<?xml version="1.0" encoding="ISO-8859-1"?>
+'<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE resultset[
 <!ELEMENT resultset (summary,results)>
 <!ELEMENT summary (status,sessionID,NumOfErrors,NumOfLikelyProblems,NumOfPotentialProblems,guidelines)>
@@ -65,6 +65,7 @@ class RESTWebServiceOutput {
 <!ENTITY amp "&#38;#38;">
 <!ENTITY apos "&#39;">
 <!ENTITY quot "&#34;">
+<!ENTITY nbsp " " >
 ]>
 <resultset>
   <summary>
@@ -225,7 +226,7 @@ class RESTWebServiceOutput {
 			                            $error['check_id'], 
 			                            htmlentities(_AC("suggest_improvements")),
 			                            htmlentities(_AC($row_check['err'])),
-			                            htmlentities($error["html_code"]),
+			                            htmlentities(utf8_decode($error["html_code"])),
 			                            $repair,
 			                            $decision),
 			                      $this->rest_result);
@@ -340,7 +341,7 @@ class RESTWebServiceOutput {
 	public static function generateSuccessRpt()
 	{
 		$rest_success = 
-'<?xml version="1.0" encoding="ISO-8859-1"?>
+'<?xml version="1.0" encoding="UTF-8"?>
 <summary>
   <status>success</status>
 </summary>


### PR DESCRIPTION
UTF-8 Encoding the REST response to avoid unidentified entity errors:

In some cases where the webpage is served with XHTML, UTF-8, but really serving ISO-8859-1, the XML that is returned, when selecting output=REST, becomes invalid.

It is full of â entities. [quote]It is an encoding issue. The non-breaking space, encoded in UTF-8 (the document makes the claim to be in UTF-8) is hex C2A0 (two bytes) but in ISO-8859-1 it is hex A0 (one byte). My browser thinks your page is ISO-8859-1. This is due to the Content-type header being incorrect.[quote]
http://ncsuwebdev.ning.com/forum/topics/the-case-of-the-mysterious
