### PR TITLE
Fix encoding error when call REST API for the pages including local characters except English

### DIFF
--- a/documentation/web_service_api.php
+++ b/documentation/web_service_api.php
@@ -322,7 +322,7 @@ in html format.</p>
 <h2 id="html_sample_response_validation">Sample HTML validation response</h2><br/>
 <span style="font-weight:bold">Success Response</span>
 <pre style="background-color:#F7F3ED;"> 
-&lt;?xml version="1.0" encoding="ISO-8859-1"?&gt;
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
 &lt;!DOCTYPE style PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"&gt;
 &lt;style type="text/css"&gt;
 ul {font-family: Arial; margin-bottom: 0px; margin-top: 0px; margin-right: 0px;}

--- a/include/classes/RESTWebServiceOutput.class.php
+++ b/include/classes/RESTWebServiceOutput.class.php
@@ -65,6 +65,7 @@ class RESTWebServiceOutput {
 <!ENTITY amp "&#38;#38;">
 <!ENTITY apos "&#39;">
 <!ENTITY quot "&#34;">
+<!ENTITY ndash "&#8211;">
 ]>
 <resultset>
   <summary>
@@ -225,7 +226,7 @@ class RESTWebServiceOutput {
 			                            $error['check_id'], 
 			                            htmlentities(_AC("suggest_improvements")),
 			                            htmlentities(_AC($row_check['err'])),
-			                            htmlentities($error["html_code"], ENT_QUOTES | ENT_IGNORE, "UTF-8"),
+			                            htmlentities($error["html_code"], ENT_QUOTES, "UTF-8"),
 			                            $repair,
 			                            $decision),
 			                      $this->rest_result);


### PR DESCRIPTION
I changed encoding ISO-8859-1 to UTF-8 for XML generation.
In case of including some local characters (in html_code), those characters are not changed properly because of ISO-8859-1 encoding when generate XML.

So we should use UTF-8 instead of ISO-8859-1.
As we know, AChecker already uses UTF-8 encoding for HTML output.
