### PR TITLE
fix label content check when the text follows enclosed input

### DIFF
--- a/include/classes/BasicFunctions.class.php
+++ b/include/classes/BasicFunctions.class.php
@@ -43,7 +43,7 @@ class BasicFunctions {
 		if ($global_e->parent()->tag == "label")
 		{
 			$pattern = "/(.*)". preg_quote($global_e->outertext, '/') ."/";
-			preg_match($pattern, $global_e->parent->innertext, $matches);
+			preg_match($pattern, $global_e->parent()->outertext, $matches);
 			if (strlen(trim($matches[1])) > 0) return true;
 		}
 		


### PR DESCRIPTION
label content following an input (e.g. checkbox) was being ignored. e.g:

```
<!DOCTYPE html>
<html lang="en">
    <head>
        <title>Test checkbox label validation</title>
    </head>
    <body>
        <p><label><input type='checkbox' value='1'> Test Label</label></p>
    </body>
</html>
```
