### PR TITLE
Conditions for highlighting menu tabs on clicking sub-menus as well

### DIFF
--- a/themes/default/include/header.tmpl.php
+++ b/themes/default/include/header.tmpl.php
@@ -118,13 +118,13 @@ $lang_charset = "UTF-8";
 	<!-- the main navigation. in our case, tabs -->
 		<ul class="navigation">
 			<?php foreach ($this->top_level_pages as $page): ?>
-				<?php $flag_highlight = false; ?>
+				<?php $is_submenu_accessed = false; ?>
 				<?php foreach ($this->sub_menus as $sub_menu) {
 					if ($page['url'] == $sub_menu['url'] || (!empty($this->back_to_page['url']) && $page['url'] == $this->back_to_page['url'])){
-						$flag_highlight = true;
+						$is_submenu_accessed = true;
 					}
 				} ?>
-				<?php if ($page['url'] == $this->current_top_level_page || $flag_highlight): ?>
+				<?php if ($page['url'] == $this->current_top_level_page || $is_submenu_accessed): ?>
 					<li class="navigation"><a href="<?php echo $page['url']; ?>" title="<?php echo $page['title']; ?>" class="active"><span class="nav"><?php echo $page['title']; ?></span></a></li>
 				<?php else: ?>
 					<li class="navigation"><a href="<?php echo $page['url']; ?>"  title="<?php echo $page['title']; ?>"><span class="nav"><?php echo $page['title']; ?></span></a></li>


### PR DESCRIPTION
Reference Issue: http://atutor.ca/atutor/mantis/view.php?id=4917
Before: Menu tab highlighting disappears on clicking sub-menu tabs of any particular menu.
After fix: The top tab menu highlighting remains as desired even if a sub-page is visited as in 'Users' tab.
