### PR TITLE
Using CURL to avoid 403 response from the w3c validator server

### DIFF
--- a/include/classes/HTMLValidator.class.php
+++ b/include/classes/HTMLValidator.class.php
@@ -83,14 +83,14 @@ class HTMLValidator {
 	function validate_uri($uri)
 	{	
 		if($ch = curl_init()) {
-	  		curl_setopt($ch, CURLOPT_URL, $this->validator_url. "?uri=".$uri);
-	  		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-	  		curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
-	  		curl_setopt ($ch, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
-	  		$pageOutput = curl_exec($ch);
-	  		curl_close($ch);
-	  		return $pageOutput;
-  		}
+			curl_setopt($ch, CURLOPT_URL, $this->validator_url. "?uri=".$uri);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+			curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+			curl_setopt ($ch, CURLOPT_USERAGENT, $_SERVER['HTTP_USER_AGENT']);
+			$pageOutput = curl_exec($ch);
+			curl_close($ch);
+			return $pageOutput;
+		}
 		else
 			return file_get_contents($this->validator_url. "?uri=".$uri);
 	}


### PR DESCRIPTION
Using file_get_contents the W3C server returns 403:
"Warning: file_get_contents(http://validator.w3.org/check?uri=http://www.google.it): failed to open stream: HTTP request failed! HTTP/1.1 403 Forbidden /...path.../"
