### PR TITLE
Call-time pass-by-reference has been deprecated in PHP 5.3

### DIFF
--- a/include/classes/BasicChecks.class.php
+++ b/include/classes/BasicChecks.class.php
@@ -158,7 +158,7 @@ class BasicChecks {
 	* Check recursively if there are duplicate $attr defined in children of $e
 	* set global var hasDuplicateAttribute to true if there is, otherwise, set it to false
 	*/
-	public static function hasDuplicateAttribute($e, $attr, &$id_array)
+	public static function hasDuplicateAttribute($e, $attr, $id_array)
 	{
 		global $has_duplicate_attribute;
 		
@@ -531,7 +531,7 @@ class BasicChecks {
 	* Check recursively if there are duplicate $attr defined in children of $e
 	* set global var $has_duplicate_attribute to true if there is, otherwise, set it to false
 	*/
-	public static function has_duplicate_attribute($e, $attr, &$id_array)
+	public static function has_duplicate_attribute($e, $attr, $id_array)
 	{
 		global $has_duplicate_attribute;
 		
@@ -693,7 +693,7 @@ class BasicChecks {
 			return true;
 	}
 	
-	public static function find_all_headers($elements, &$header_array)
+	public static function find_all_headers($elements, $header_array)
 	{
 		foreach ($elements as $e)
 		{

--- a/include/classes/Savant2/Savant2.php
+++ b/include/classes/Savant2/Savant2.php
@@ -401,7 +401,7 @@ class Savant2 {
 	* 
 	*/
 	
-	function setCompiler(&$compiler)
+	function setCompiler($compiler)
 	{
 		if (! $compiler) {
 			// nullify any current compiler
@@ -1057,7 +1057,7 @@ class Savant2 {
 	* 
 	* @param string $key The name for the reference in the template.
 	*
-	* @param mixed &$val The referenced variable.
+	* @param mixed $val The referenced variable.
 	* 
 	* @return void
 	* 
@@ -1065,7 +1065,7 @@ class Savant2 {
 	* 
 	*/
 	
-	function assignRef($key, &$val)
+	function assignRef($key, $val)
 	{
 		if (is_string($key) && substr($key, 0, 1) != '_') {
 			$this->$key = $val;
@@ -1490,7 +1490,7 @@ class Savant2 {
 		$args = func_get_args();
 		array_shift($args);
 		return call_user_func_array(
-			array(&$this->_resource['plugin'][$name], 'plugin'), $args
+			array($this->_resource['plugin'][$name], 'plugin'), $args
 		);
 	}
 	
@@ -1516,7 +1516,7 @@ class Savant2 {
 		$args = func_get_args();
 		
 		$result = call_user_func_array(
-			array(&$this, 'splugin'),
+			array($this, 'splugin'),
 			$args
 		);
 		
@@ -1556,7 +1556,7 @@ class Savant2 {
 		
 		// call the plugin() method
 		return call_user_func_array(
-			array(&$this, $this->_call),
+			array($this, $this->_call),
 			$args
 		);
 	}
@@ -1771,14 +1771,14 @@ class Savant2 {
 	* 
 	* @access public
 	* 
-	* @param object &$obj The object to be tested.
+	* @param object $obj The object to be tested.
 	* 
 	* @return boolean True if $obj is an error object of the type
 	* Savant2_Error, or is a subclass that Savant2_Error. False if not.
 	*
 	*/
 	
-	function isError(&$obj)
+	function isError($obj)
 	{
 		if (is_object($obj)) {
 			if (is_a($obj, 'Savant2_Error') ||

--- a/include/classes/sqlutility.class.php
+++ b/include/classes/sqlutility.class.php
@@ -25,7 +25,7 @@ class SqlUtility
  	* @return  boolean  always true
  	* @access  public
  	*/
-	function splitSqlFile(&$ret, $sql)
+	function splitSqlFile($ret, $sql)
 	{
 		$sql               = trim($sql);
 		$sql_len           = strlen($sql);

--- a/include/lib/pclzip.lib.php
+++ b/include/lib/pclzip.lib.php
@@ -1734,7 +1734,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privCreate($p_list, &$p_result_list, $p_add_dir, $p_remove_dir, $p_remove_all_dir, &$p_options)
+  function privCreate($p_list, $p_result_list, $p_add_dir, $p_remove_dir, $p_remove_all_dir, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privCreate", "list, result_list, add_dir='$p_add_dir', remove_dir='$p_remove_dir'");
     $v_result=1;
@@ -1766,7 +1766,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privAdd($p_list, &$p_result_list, $p_add_dir, $p_remove_dir, $p_remove_all_dir, &$p_options)
+  function privAdd($p_list, $p_result_list, $p_add_dir, $p_remove_dir, $p_remove_all_dir, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privAdd", "list, result_list, add_dir='$p_add_dir', remove_dir='$p_remove_dir'");
     $v_result=1;
@@ -2016,7 +2016,7 @@
   //   $p_remove_dir : Path to remove in the filename path archived
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privAddList($p_list, &$p_result_list, $p_add_dir, $p_remove_dir, $p_remove_all_dir, &$p_options)
+  function privAddList($p_list, $p_result_list, $p_add_dir, $p_remove_dir, $p_remove_all_dir, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privAddList", "list, add_dir='$p_add_dir', remove_dir='$p_remove_dir'");
     $v_result=1;
@@ -2089,7 +2089,7 @@
   //   $p_remove_dir : Path to remove in the filename path archived
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privAddFileList($p_list, &$p_result_list, $p_add_dir, $p_remove_dir, $p_remove_all_dir, &$p_options)
+  function privAddFileList($p_list, $p_result_list, $p_add_dir, $p_remove_dir, $p_remove_all_dir, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privAddFileList", "list, add_dir='$p_add_dir', remove_dir='$p_remove_dir'");
     $v_result=1;
@@ -2221,7 +2221,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privAddFile($p_filename, &$p_header, $p_add_dir, $p_remove_dir, $p_remove_all_dir, &$p_options)
+  function privAddFile($p_filename, $p_header, $p_add_dir, $p_remove_dir, $p_remove_all_dir, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privAddFile", "filename='$p_filename', add_dir='$p_add_dir', remove_dir='$p_remove_dir'");
     $v_result=1;
@@ -2486,7 +2486,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privWriteFileHeader(&$p_header)
+  function privWriteFileHeader($p_header)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privWriteFileHeader", 'file="'.$p_header['filename'].'", stored as "'.$p_header['stored_filename'].'"');
     $v_result=1;
@@ -2540,7 +2540,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privWriteCentralFileHeader(&$p_header)
+  function privWriteCentralFileHeader($p_header)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privWriteCentralFileHeader", 'file="'.$p_header['filename'].'", stored as "'.$p_header['stored_filename'].'"');
     $v_result=1;
@@ -2627,7 +2627,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privList(&$p_list)
+  function privList($p_list)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privList", "list");
     $v_result=1;
@@ -2711,7 +2711,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privConvertHeader2FileInfo($p_header, &$p_info)
+  function privConvertHeader2FileInfo($p_header, $p_info)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privConvertHeader2FileInfo", "Filename='".$p_header['filename']."'");
     $v_result=1;
@@ -2749,7 +2749,7 @@
   // Return Values :
   //   1 on success,0 or less on error (see error code list)
   // --------------------------------------------------------------------------------
-  function privExtractByRule(&$p_file_list, $p_path, $p_remove_path, $p_remove_all_path, &$p_options)
+  function privExtractByRule($p_file_list, $p_path, $p_remove_path, $p_remove_all_path, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privExtractByRule", "path='$p_path', remove_path='$p_remove_path', remove_all_path='".($p_remove_all_path?'true':'false')."'");
     $v_result=1;
@@ -3107,7 +3107,7 @@
   // 1 : ... ?
   // PCLZIP_ERR_USER_ABORTED(2) : User ask for extraction stop in callback
   // --------------------------------------------------------------------------------
-  function privExtractFile(&$p_entry, $p_path, $p_remove_path, $p_remove_all_path, &$p_options)
+  function privExtractFile($p_entry, $p_path, $p_remove_path, $p_remove_all_path, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, 'PclZip::privExtractFile', "path='$p_path', remove_path='$p_remove_path', remove_all_path='".($p_remove_all_path?'true':'false')."'");
     $v_result=1;
@@ -3471,7 +3471,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privExtractFileInOutput(&$p_entry, &$p_options)
+  function privExtractFileInOutput($p_entry, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, 'PclZip::privExtractFileInOutput', "");
     $v_result=1;
@@ -3596,7 +3596,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privExtractFileAsString(&$p_entry, &$p_string)
+  function privExtractFileAsString($p_entry, $p_string)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, 'PclZip::privExtractFileAsString', "p_entry['filename']='".$p_entry['filename']."'");
     $v_result=1;
@@ -3664,7 +3664,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privReadFileHeader(&$p_header)
+  function privReadFileHeader($p_header)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privReadFileHeader", "");
     $v_result=1;
@@ -3789,7 +3789,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privReadCentralFileHeader(&$p_header)
+  function privReadCentralFileHeader($p_header)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privReadCentralFileHeader", "");
     $v_result=1;
@@ -3924,7 +3924,7 @@
   //   1 on success,
   //   0 on error;
   // --------------------------------------------------------------------------------
-  function privCheckFileHeaders(&$p_local_header, &$p_central_header)
+  function privCheckFileHeaders($p_local_header, $p_central_header)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privCheckFileHeaders", "");
     $v_result=1;
@@ -3974,7 +3974,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privReadEndCentralDir(&$p_central_dir)
+  function privReadEndCentralDir($p_central_dir)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privReadEndCentralDir", "");
     $v_result=1;
@@ -4159,7 +4159,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privDeleteByRule(&$p_result_list, &$p_options)
+  function privDeleteByRule($p_result_list, $p_options)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privDeleteByRule", "");
     $v_result=1;
@@ -4577,7 +4577,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privMerge(&$p_archive_to_add)
+  function privMerge($p_archive_to_add)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, "PclZip::privMerge", "archive='".$p_archive_to_add->zipname."'");
     $v_result=1;
@@ -4890,7 +4890,7 @@
   // Parameters :
   // Return Values :
   // --------------------------------------------------------------------------------
-  function privDecrypt($p_encryption_header, &$p_buffer, $p_size, $p_crc)
+  function privDecrypt($p_encryption_header, $p_buffer, $p_size, $p_crc)
   {
     //--(MAGIC-PclTrace)--//PclTraceFctStart(__FILE__, __LINE__, 'PclZip::privDecrypt', "size=".$p_size."");
     $v_result=1;

--- a/include/lib/simple_html_dom.php
+++ b/include/lib/simple_html_dom.php
@@ -297,7 +297,7 @@ class simple_html_dom_node {
     }
 
     // seek for given conditions
-    protected function seek($selector, &$ret) {
+    protected function seek($selector, $ret) {
         list($tag, $key, $val, $exp) = $selector;
 
         $end = $this->info[HDOM_INFO_END];
@@ -757,7 +757,7 @@ class simple_html_dom {
     /* end of customized by UOT, ATRC, cindy Li */
     
     // parse attributes
-    protected function parse_attr($node, $name, &$space) {
+    protected function parse_attr($node, $name, $space) {
         $space[2] = $this->copy_skip($this->token_blank);
         switch($this->char) {
             case '"':

--- a/include/phpCache/phpCache.inc.php
+++ b/include/phpCache/phpCache.inc.php
@@ -90,7 +90,7 @@ if (!defined('CACHE_DIR')) {
 	}
 
 	/* This is a function used internally by phpCache to evaluate the conditional expiration.  This allows the eval() to have its own simulated namespace so it doesnt conflict with any others. */
-	function cache_eval_expire($cond, &$vars) {
+	function cache_eval_expire($cond, $vars) {
 		extract($vars);
 		$EXPIRE=FALSE;
 		eval($cond);

--- a/install/include/classes/sqlutility.php
+++ b/install/include/classes/sqlutility.php
@@ -25,7 +25,7 @@ class SqlUtility
  	* @return  boolean  always true
  	* @access  public
  	*/
-	function splitSqlFile(&$ret, $sql)
+	function splitSqlFile($ret, $sql)
 	{
 		$sql               = trim($sql);
 		$sql_len           = strlen($sql);


### PR DESCRIPTION
This removes the call by reference so Achecker is able to work with PHP 5.4.