### PR TITLE
Support X-Forwarded-Proto

### DIFF
--- a/include/constants.inc.php
+++ b/include/constants.inc.php
@@ -161,7 +161,10 @@ if (strpos(@ini_get('arg_separator.input'), ';') !== false) {
 }
 
 /* get the base url	*/
-if (isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) == 'on')) {
+if (
+    (isset($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) == 'on') ||
+    (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')
+) {
 	$server_protocol = 'https://';
 } else {
 	$server_protocol = 'http://';

--- a/include/constants.inc.php
+++ b/include/constants.inc.php
@@ -161,7 +161,7 @@ if (strpos(@ini_get('arg_separator.input'), ';') !== false) {
 }
 
 /* get the base url	*/
-if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) {
+if (isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) == 'on')) {
 	$server_protocol = 'https://';
 } else {
 	$server_protocol = 'http://';

--- a/include/constants.inc.php
+++ b/include/constants.inc.php
@@ -161,7 +161,7 @@ if (strpos(@ini_get('arg_separator.input'), ';') !== false) {
 }
 
 /* get the base url	*/
-if (isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) == 'on')) {
+if (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && (strtolower($_SERVER['HTTP_X_FORWARDED_PROTO']) == 'https')) {
 	$server_protocol = 'https://';
 } else {
 	$server_protocol = 'http://';


### PR DESCRIPTION
This is necessary to correctly work behind load balancers. In that case, $_SERVER['HTTPS'] is not defined because the TLS connection is terminated on the load balancer and only HTTP requests reach the application.

X-Forwarded-Proto is a defacto standard (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html)