### PR TITLE
ACHECKER-3: Fixing Issue with last_updated syntax

### DIFF
--- a/install/db/achecker_schema.sql
+++ b/install/db/achecker_schema.sql
@@ -308,7 +308,7 @@ CREATE TABLE `themes` (
   `title` varchar(80) NOT NULL DEFAULT '',
   `version` varchar(10) NOT NULL DEFAULT '',
   `dir_name` varchar(20) NOT NULL DEFAULT '',
-  `last_updated` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `extra_info` text,
   `status` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`title`)

--- a/install/db/achecker_schema.sql
+++ b/install/db/achecker_schema.sql
@@ -308,7 +308,7 @@ CREATE TABLE `themes` (
   `title` varchar(80) NOT NULL DEFAULT '',
   `version` varchar(10) NOT NULL DEFAULT '',
   `dir_name` varchar(20) NOT NULL DEFAULT '',
-  `last_updated` date NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_updated` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `extra_info` text,
   `status` tinyint(3) unsigned NOT NULL DEFAULT '1',
   PRIMARY KEY (`title`)

--- a/install/db/achecker_upgrade_1.4_to_1.5.sql
+++ b/install/db/achecker_upgrade_1.4_to_1.5.sql
@@ -11,7 +11,7 @@ ALTER TABLE `checks` MODIFY `create_date` datetime DEFAULT NULL;
 
 ALTER TABLE `language_text` MODIFY `revised_date` datetime default NULL;
 
-ALTER TABLE `themes` MODIFY `last_updated` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE `themes` MODIFY `last_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
 UPDATE `checks` SET create_date = NULL WHERE create_date = '0000-00-00 00:00:00';
 

--- a/install/db/achecker_upgrade_1.4_to_1.5.sql
+++ b/install/db/achecker_upgrade_1.4_to_1.5.sql
@@ -11,7 +11,7 @@ ALTER TABLE `checks` MODIFY `create_date` datetime DEFAULT NULL;
 
 ALTER TABLE `language_text` MODIFY `revised_date` datetime default NULL;
 
-ALTER TABLE `themes` MODIFY `last_updated` date NOT NULL DEFAULT CURRENT_TIMESTAMP;
+ALTER TABLE `themes` MODIFY `last_updated` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
 
 UPDATE `checks` SET create_date = NULL WHERE create_date = '0000-00-00 00:00:00';
 


### PR DESCRIPTION
Notice an issue with the use of ``` 'last_updated' date NOT NULL DEFAULT CURRENT_TIMESTAMP``` , which is supposed to be ```'last_updated' TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP```