### PR TITLE
ACHECKER-5

### DIFF
--- a/include/classes/BasicChecks.class.php
+++ b/include/classes/BasicChecks.class.php
@@ -2288,8 +2288,6 @@ class BasicChecks {
 		foreach ( $a_value as $value ) {
 			if (substr ( $value, strlen ( $value ) - 2, 2 ) == "px")
 				$ret = true;
-			//else
-		//	return false;
 		}
 		return $ret;
 	}

--- a/include/classes/DAO/DAO.class.php
+++ b/include/classes/DAO/DAO.class.php
@@ -21,10 +21,10 @@
 
 class DAO {
 
-	// private
-	private $db;      // global database connection
+	// protected	+	// private
+	protected $db;      // global database connection
 
-	function __construct()
+	function __construct($db_host = NULL, $db_user = NULL, $db_pass = NULL, $db_name = NULL, $db_port = NULL)
 	{
 		if(!isset($db_host) || !isset($db_user) || !isset($db_pass) || !isset($db_name) || !isset($db_port))
 		{	

--- a/include/classes/sqlutility.class.php
+++ b/include/classes/sqlutility.class.php
@@ -25,7 +25,7 @@ class SqlUtility
  	* @return  boolean  always true
  	* @access  public
  	*/
-	function splitSqlFile($ret, $sql)
+	function splitSqlFile(&$ret, $sql)
 	{
 		$sql               = trim($sql);
 		$sql_len           = strlen($sql);
@@ -159,7 +159,7 @@ class SqlUtility
         }
 
         $sql_query = trim(fread(fopen($sql_file_path, 'r'), filesize($sql_file_path)));
-        SqlUtility::splitSqlFile($pieces, $sql_query);
+        $this->splitSqlFile($pieces, $sql_query);
 
 	    foreach ($pieces as $piece) {
 	        $piece = trim($piece);
@@ -167,7 +167,7 @@ class SqlUtility
             // [4] contains unprefixed table name
 
 			if ($table_prefix || ($table_prefix == '')) {
-	            $prefixed_query = SqlUtility::prefixQuery($piece, $table_prefix);
+	            $prefixed_query = $this->prefixQuery($piece, $table_prefix);
 			} else {
 				$prefixed_query = $piece;
 			}

--- a/install/include/classes/sqlutility.php
+++ b/install/include/classes/sqlutility.php
@@ -25,7 +25,7 @@ class SqlUtility
  	* @return  boolean  always true
  	* @access  public
  	*/
-	function splitSqlFile($ret, $sql)
+	function splitSqlFile(&$ret, $sql)
 	{
 		$sql               = trim($sql);
 		$sql_len           = strlen($sql);


### PR DESCRIPTION
Error:
Invalid argument supplied for foreach()
Problem File:

```install\include\classes\sqlutility.php```
The line of Code:
Line 28 ```function splitSqlFile(&$ret, $sql)```

Removing the ```&``` symbol does result in an error involving foreach loop,

Looking at the [documentation](http://php.net/manual/en/language.references.pass.php)
```The following things can be passed by reference:
Variables, i.e. foo($a)
References returned from functions, i.e.:
<?php
function foo(&$var)
{
    $var++;
}
function &bar()
{
    $a = 5;
    return $a;
}
foo(bar());
?>
```
A more detailed report can be found [here](https://stackoverflow.com/questions/51110043/getting-invalid-argument-supplied-for-foreach-as-a-result-of-pass-by-reference-v/51110323#51110323)